### PR TITLE
set encoding option to null for getMessageContent

### DIFF
--- a/lib/linebot.js
+++ b/lib/linebot.js
@@ -99,7 +99,7 @@ function LINEBot(client, channelSecret, options) {
   }
 
   this.getMessageContent = function(messageId) {
-    return client.get(endpointBase + '/v2/bot/message/' + encodeURIComponent(messageId) + '/content');
+    return client.get(endpointBase + '/v2/bot/message/' + encodeURIComponent(messageId) + '/content', null);
   }
 
   this.replyMessage = function(replyToken, messageBuilder) {

--- a/lib/linebot/lineclient.js
+++ b/lib/linebot/lineclient.js
@@ -7,15 +7,15 @@ function LINEClient(channelToken) {
 
   var that = this;
 
-  this.get = function(url) {
-    return that.sendRequest('GET', url);
+  this.get = function(url, encoding) {
+    return that.sendRequest('GET', url, {}, null, encoding);
   }
 
   this.post = function(url, data) {
     return that.sendRequest('POST', url, { 'Content-Type': 'application/json; charset=utf-8' }, data);
   }
 
-  this.sendRequest = function(method, url, additionalHeader, reqBody) {
+  this.sendRequest = function(method, url, additionalHeader, reqBody, encoding) {
     if ( additionalHeader && Object.keys(additionalHeader).length > 0 ) {
       for ( var i in additionalHeader ) {
         headers[i] = additionalHeader[i];
@@ -30,6 +30,7 @@ function LINEClient(channelToken) {
     };
 
     if ( reqBody ) options.body = reqBody;
+    if ( typeof encoding !== 'undefined' ) options.encoding = encoding;
 
     return new Promise(function(resolve, reject) {
       request(options, function(error, response, body) {


### PR DESCRIPTION
Hi snlangsuan

I  found a trouble when I used getMessageContent to get my image data.
The received image data was seemed to be encoded to UTF-8.
But image data is binary data.
I think this trouble is caused by wrong setting for request module.
This commit adds encofing field to get binary data.

Please see the following description from https://github.com/request/request/blob/master/README.md

encoding - Encoding to be used on setEncoding of response data. If null, the body is returned as a Buffer. Anything else (including the default value of undefined) will be passed as the encoding parameter to toString() (meaning this is effectively utf8 by default). (Note: if you expect binary data, you should set encoding: null.)